### PR TITLE
🛡️ Sentinel: [security improvement] Add base-uri to CSP and Referrer-Policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; form-action 'none';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; form-action 'none'; base-uri 'none';">
+<meta name="referrer" content="no-referrer">
 <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `base-uri` in Content-Security-Policy could allow an attacker to inject a `<base>` tag (if an HTML injection vulnerability existed) to hijack relative URLs. The application also previously had no `Referrer-Policy`, meaning it could leak its origin and query parameters to external sites in the `Referer` header.
🎯 Impact: An injected `<base>` tag could redirect relative paths (like stylesheets, scripts) to an attacker-controlled server, leading to XSS. The referrer policy protects against accidental information leakage to external links (e.g., the GitHub link).
🔧 Fix: Added `base-uri 'none'` to the CSP `<meta>` tag to strictly prevent base tags from functioning, and added `<meta name="referrer" content="no-referrer">` to stop sending the `Referer` header to external sites.
✅ Verification: Start a local server (`python3 -m http.server 8000`), load the site, and verify the CSP restricts `<base>` elements, and that navigating to the GitHub link does not send the original site's URL as the referrer.

---
*PR created automatically by Jules for task [5589665369941408636](https://jules.google.com/task/5589665369941408636) started by @ycechungAI*