### PR TITLE
🛡️ Sentinel: [HIGH] Fix Clickjacking Frame-busting Execution Continuation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Clickjacking risk when X-Frame-Options or CSP frame-ancestors headers are unavailable.
 **Learning:** Static sites relying on meta tags for CSP cannot use frame-ancestors. Frame-busting JavaScript must be implemented instead to prevent UI redress attacks.
 **Prevention:** Always implement frame-busting JS in the main script for statically hosted applications that lack server-level header configuration.
+
+## 2026-03-03 - Execution Continuation in Frame-Busting Scripts
+**Vulnerability:** Clickjacking frame-busting logic does not halt execution (DOM clears but script continues).
+**Learning:** Frame-busting logic placed inside an IIFE (Immediately Invoked Function Expression) requires explicit halting to prevent the remainder of the script from executing after the clickjacking attempt is detected. However, a global `return;` is illegal in unbundled scripts and causes a `SyntaxError`.
+**Prevention:** Always use `throw new Error()` inside clickjacking defense blocks to safely halt script execution and prevent unintended code from running while framed.

--- a/diablo.js
+++ b/diablo.js
@@ -8,6 +8,7 @@ if (window.top !== window.self) {
         // If we can't redirect the top window (e.g. sandbox restriction), clear the body
         document.body.innerHTML = '<h1>Clickjacking Protection</h1><p>This content cannot be displayed in a frame.</p>';
     }
+    throw new Error('Clickjacking detected');
 }
 
 var imageCount=0;


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The clickjacking frame-busting logic in `diablo.js` cleared the DOM but failed to halt the rest of the script. This meant the game logic continued executing while framed.
🎯 **Impact**: Allowed the game script to execute in a potentially malicious framing context.
🔧 **Fix**: Added a `throw new Error()` statement inside the frame-busting `if` block to safely and immediately halt execution when clickjacking is detected.
✅ **Verification**: Verified via Playwright that normal functionality is untouched, and verified via local mock that script throws an error and exits immediately when `window.top !== window.self`.

---
*PR created automatically by Jules for task [5770210696599215681](https://jules.google.com/task/5770210696599215681) started by @ycechungAI*